### PR TITLE
feat(ci): fix workflow for Go rewrite + pull image from GHCR on server

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,25 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  test:
+    name: Go tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./internal/... -count=1 -timeout 120s
+
   build-and-push:
+    name: Build and push image
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,6 +66,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: Dockerfile.go
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/docker-compose.go.yml
+++ b/docker-compose.go.yml
@@ -1,6 +1,8 @@
 services:
   cascade:
-    image: cascade:latest
+    # Pre-built image from GitHub Actions CI (pushed on every merge to master).
+    # To use a locally-built image instead, run ./build-go.sh and set image: cascade:latest
+    image: ghcr.io/johnnybut/cascade:latest
     container_name: cascade
     restart: unless-stopped
 


### PR DESCRIPTION
.github/workflows/docker-publish.yml:
- Add `test` job: go test ./internal/... before build (build-and-push needs: test)
- Add `file: Dockerfile.go` — was missing, caused workflow to fail (no Dockerfile)
- Split into two jobs: test → build-and-push for clearer failure reporting

docker-compose.go.yml:
- image: ghcr.io/johnnybut/cascade:latest (pre-built by CI)
- Server deploy is now: docker compose pull && docker compose up -d
- No more git pull + build-go.sh required on server after initial setup

Caddy stays separate (deploy/caddy/) — uses official caddy:alpine, no custom build.