### PR TITLE
feat(deploy): use GHCR image in production, local override for dev

### DIFF
--- a/build-go.sh
+++ b/build-go.sh
@@ -14,10 +14,13 @@ echo ""
 
 cd "$(dirname "$0")"
 
-# Verify we're on the right branch
+# Verify we're not on master (local builds are for development only)
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$BRANCH" != "feature/go-rewrite" ]]; then
-    echo -e "${YELLOW}Warning: not on feature/go-rewrite (current: $BRANCH)${NC}"
+if [[ "$BRANCH" == "master" ]]; then
+    echo -e "${YELLOW}Note: on master branch. Production deploys use the GHCR image:${NC}"
+    echo -e "  docker compose -f docker-compose.go.yml pull"
+    echo -e "  docker compose -f docker-compose.go.yml up -d"
+    echo -e "${YELLOW}Building locally anyway (e.g. for testing before push)...${NC}"
 fi
 
 echo -e "${GREEN}Building Docker image (Go/Fiber)...${NC}"
@@ -37,11 +40,13 @@ echo -e "${GREEN}✓ Build complete!${NC}"
 echo ""
 echo "Image tag: cascade:latest"
 echo ""
-echo "Next steps:"
-echo "  1. Edit docker-compose.go.yml with your settings (WG_HOST, PASSWORD_HASH)"
-echo "  2. Deploy:"
-echo "     ${COMPOSE} -f docker-compose.go.yml down && ${COMPOSE} -f docker-compose.go.yml up -d"
-echo "  3. Check logs:"
-echo "     docker logs cascade"
-echo "  4. Healthcheck:"
-echo "     curl http://127.0.0.1:8888/api/health"
+echo "Next steps (local dev with locally-built image):"
+echo "  ${COMPOSE} -f docker-compose.go.yml -f docker-compose.override.yml down"
+echo "  ${COMPOSE} -f docker-compose.go.yml -f docker-compose.override.yml up -d"
+echo ""
+echo "  docker logs cascade"
+echo "  curl http://127.0.0.1:8888/api/health"
+echo ""
+echo -e "${YELLOW}Production deploy (uses GHCR image built by CI):${NC}"
+echo "  ${COMPOSE} -f docker-compose.go.yml pull"
+echo "  ${COMPOSE} -f docker-compose.go.yml up -d"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -400,23 +400,16 @@ echo -e "${B}── Step 5: Build Cascade${N}"
 cd "$REPO_DIR"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-if [[ "$BRANCH" != "feature/go-rewrite" ]]; then
-  warn "Current branch: $BRANCH (expected feature/go-rewrite)"
-fi
 
-info "Pulling latest changes..."
-git pull origin "$BRANCH" 2>&1 | tail -1
+info "Pulling latest changes from master..."
+git pull origin master 2>&1 | tail -1
 
-if docker image inspect cascade:latest &>/dev/null; then
-  ok "Image cascade:latest already built"
-  if [[ $YES -eq 0 ]]; then
-    read -rp "  Rebuild? [y/N]: " REBUILD
-    [[ "${REBUILD,,}" == "y" ]] && bash build-go.sh
-  fi
+info "Pulling Cascade image from GHCR..."
+if $COMPOSE_CMD -f "$REPO_DIR/docker-compose.go.yml" pull; then
+  ok "Image pulled: ghcr.io/johnnybut/cascade:latest"
 else
-  info "Building Docker image..."
+  warn "Could not pull GHCR image — falling back to local build"
   bash build-go.sh
-  ok "Image built"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -634,7 +627,8 @@ echo -e "    3. Create your admin account"
 echo -e "    4. Enable TOTP in Settings → Users for added security"
 echo ""
 echo -e "  ${Y}Update:${N}"
-echo -e "    git pull origin feature/go-rewrite && ./build-go.sh"
+echo -e "    git pull origin master"
+echo -e "    docker compose -f docker-compose.go.yml pull"
 echo -e "    docker compose -f docker-compose.go.yml up -d"
 echo ""
 echo -e "  ${Y}Logs:${N}"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,12 @@
+# Local development override — use locally-built image instead of GHCR.
+#
+# Usage:
+#   ./build-go.sh                          # builds cascade:latest locally
+#   docker compose -f docker-compose.go.yml -f docker-compose.override.yml up -d
+#
+# This file is NOT used in production (server pulls from ghcr.io).
+# It is git-ignored by default — copy to your working dir as needed.
+
+services:
+  cascade:
+    image: cascade:latest

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -90,18 +90,21 @@ sysctl --system
 ```bash
 git clone https://github.com/JohnnyVBut/cascade.git
 cd cascade
-git checkout feature/go-rewrite
 ```
 
 ---
 
-## Step 6 — Build Cascade (Go binary + Docker image)
+## Step 6 — Pull Cascade image
+
+The Docker image is built by GitHub Actions on every merge to `master` and published
+to GitHub Container Registry. No local build required:
 
 ```bash
-./build-go.sh
+docker compose -f docker-compose.go.yml pull
 ```
 
-The script compiles the Go binary and builds the Docker image `awg2-easy-go:latest`.
+> **Local development only:** to use a locally-built image, run `./build-go.sh`
+> and add `-f docker-compose.override.yml` to your compose commands.
 
 ---
 
@@ -123,7 +126,7 @@ environment:
 **Optional — pre-set password hash (non-interactive / CI):**
 
 ```bash
-docker run --rm -it awg2-easy-go:latest /app/cascade hash
+docker run --rm -it ghcr.io/johnnybut/cascade:latest /app/cascade hash
 # Enter password when prompted — copy the $2a$... hash into PASSWORD_HASH=
 ```
 
@@ -316,10 +319,13 @@ The data directory is mounted into the container via `docker-compose.go.yml`.
 
 ```bash
 cd ~/cascade
-git pull origin feature/go-rewrite
-./build-go.sh
+git pull origin master
+docker compose -f docker-compose.go.yml pull
 docker compose -f docker-compose.go.yml up -d
 ```
+
+The image is pre-built by CI — `docker compose pull` fetches the latest version
+from GHCR without compiling anything on the server.
 
 Caddy does not need to be restarted for Cascade updates.
 


### PR DESCRIPTION
docker-compose.override.yml (new):
- Overrides image to cascade:latest (locally built)
- Used in dev: docker compose -f docker-compose.go.yml -f docker-compose.override.yml up -d

build-go.sh:
- Warn on master branch: suggest pull+up instead of local build
- Updated "Next steps" to show both dev (with override) and prod (pull from GHCR) commands

deploy/setup.sh:
- git pull origin master (was: feature/go-rewrite)
- docker compose pull from GHCR instead of bash build-go.sh
- Fallback to build-go.sh if pull fails (e.g. no internet / private repo)
- Update summary "Update" command to use docker compose pull

docs/DEPLOY.md:
- Step 5: clone master (no git checkout feature/go-rewrite)
- Step 6: docker compose pull instead of ./build-go.sh
- Updating section: git pull master + docker compose pull
- hash command: ghcr.io/johnnybut/cascade:latest (was: awg2-easy-go:latest)