### PR TITLE
docs: update README deploy commands — docker compose pull instead of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You are responsible for network security, authentication and access control.
 ```bash
 git clone https://github.com/JohnnyVBut/cascade.git
 cd cascade
-./build-go.sh
+docker compose -f docker-compose.go.yml pull
 docker compose -f docker-compose.go.yml up -d
 # UI available at http://127.0.0.1:8888/
 ```
@@ -202,9 +202,9 @@ Full threat model: [docs/SECURITY.md](docs/SECURITY.md)
 ## 🔄 Updating
 
 ```bash
-git pull origin feature/go-rewrite
-./build-go.sh
-docker compose -f docker-compose.go.yml down && docker compose -f docker-compose.go.yml up -d
+git pull origin master
+docker compose -f docker-compose.go.yml pull
+docker compose -f docker-compose.go.yml up -d
 ```
 
 ## 📱 Compatible VPN Clients

--- a/README.ru.md
+++ b/README.ru.md
@@ -107,7 +107,7 @@ sudo bash deploy/switch-mode.sh --kernel      # → kernel-модуль (быс�
 ```bash
 git clone https://github.com/JohnnyVBut/cascade.git
 cd cascade
-./build-go.sh
+docker compose -f docker-compose.go.yml pull
 docker compose -f docker-compose.go.yml up -d
 # UI доступен на http://127.0.0.1:8888/
 ```
@@ -203,9 +203,9 @@ Admin URL: https://ВАШ_IP/<секретный-путь>/
 ## 🔄 Обновление
 
 ```bash
-git pull origin feature/go-rewrite
-./build-go.sh
-docker compose -f docker-compose.go.yml down && docker compose -f docker-compose.go.yml up -d
+git pull origin master
+docker compose -f docker-compose.go.yml pull
+docker compose -f docker-compose.go.yml up -d
 ```
 
 ## 📱 Совместимые VPN-клиенты


### PR DESCRIPTION
…build-go.sh

README.md + README.ru.md:
- Option A (router only): docker compose pull instead of ./build-go.sh
- Updating section: git pull master + docker compose pull (no local build)