### PR TITLE
fix(deploy): correct GHCR image name — johnnybut → johnnyvbut

### DIFF
--- a/docker-compose.go.yml
+++ b/docker-compose.go.yml
@@ -2,7 +2,7 @@ services:
   cascade:
     # Pre-built image from GitHub Actions CI (pushed on every merge to master).
     # To use a locally-built image instead, run ./build-go.sh and set image: cascade:latest
-    image: ghcr.io/johnnybut/cascade:latest
+    image: ghcr.io/johnnyvbut/cascade:latest
     container_name: cascade
     restart: unless-stopped
 


### PR DESCRIPTION
Typo in docker-compose.go.yml: missing 'v' in owner name. ghcr.io/johnnybut/cascade → ghcr.io/johnnyvbut/cascade