### PR TITLE
ci: force Node.js 24 for all actions — suppress deprecation warnings

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   test:


### PR DESCRIPTION
FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true opts in to Node.js 24 runtime for all actions (checkout, setup-go, docker/* actions) ahead of the forced migration on June 2, 2026.